### PR TITLE
fix: add default -O0 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ module.exports = {
   include: ["source", "tests"],
   exclude: [],
 
-  /** optional: assemblyscript compile flag, default is --exportStart _start */
+  /** optional: assemblyscript compile flag, default is --exportStart _start -O0 */
   flags: "",
 
   /**

--- a/as-test.config.cjs
+++ b/as-test.config.cjs
@@ -5,7 +5,7 @@ module.exports = {
   /** optional: file exclude */
   exclude: [],
 
-  /** optional: assemblyscript compile flag, default is --exportStart _start */
+  /** optional: assemblyscript compile flag, default is --exportStart _start -O0 */
   flags: "",
 
   /**

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -20,6 +20,7 @@ export async function compile(testCodePaths: string[], outputFolder: string, com
       "_start",
       "--sourceMap",
       "--debug",
+      "-O0",
     ];
     if (compileFlags) {
       const argv = compileFlags.split(" ");

--- a/src/core/precompile.ts
+++ b/src/core/precompile.ts
@@ -64,6 +64,7 @@ async function transform(sourceCodePath: string, transformFunction: string) {
     "--disableWarning",
     "--transform",
     transformFunction,
+    "-O0",
   ]);
   if (error) {
     // eslint-disable-next-line @typescript-eslint/no-base-to-string


### PR DESCRIPTION
asc compiler will read `asconfig.json` in project folder by default. Add `-O0` option can force disable optimization since ut cannot be used under optimization build.